### PR TITLE
Stop spamming Genisys' webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,3 @@ before_script:
 
 script:
  - ./travis.sh
-
-notifications:
-  email: false
-  webhooks:
-    urls:
-     - https://webhooks.gitter.im/e/e51c4708fdbca6d5ee37
-    on_success: change  # options: [always|never|change] default: always
-    on_failure: always  # options: [always|never|change] default: always
-    on_start: never     # options: [always|never|change] default: always


### PR DESCRIPTION
Your Travis builds are spamming our Gitter webhook because you copied our .travis.yml. Please remove it.